### PR TITLE
Hide noisy tsoa routes gen warnings

### DIFF
--- a/src/swagger/specGenerator.ts
+++ b/src/swagger/specGenerator.ts
@@ -149,15 +149,15 @@ export abstract class SpecGenerator {
     if (dataType === 'object') {
       if (process.env.NODE_ENV !== 'tsoa_test') {
         // tslint:disable-next-line: no-console
-        console.warn(`The type Object is discouraged. Please consider using an interface such as:
-          export interface IStringToStringDictionary {
-            [key: string]: string;
-          }
-          // or
-          export interface IRecordOfAny {
-            [key: string]: any;
-          }
-        `);
+        // console.warn(`The type Object is discouraged. Please consider using an interface such as:
+        //   export interface IStringToStringDictionary {
+        //     [key: string]: string;
+        //   }
+        //   // or
+        //   export interface IRecordOfAny {
+        //     [key: string]: any;
+        //   }
+        // `);
       }
     }
 

--- a/src/swagger/specGenerator2.ts
+++ b/src/swagger/specGenerator2.ts
@@ -302,7 +302,7 @@ export class SpecGenerator2 extends SpecGenerator {
   protected getSwaggerTypeForUnionType(type: Tsoa.UnionType) {
     if (process.env.NODE_ENV !== 'tsoa_test') {
       // tslint:disable-next-line: no-console
-      console.warn('Swagger 2.0 does not support union types beyond string literals.\n' + 'If you would like to take advantage of this, please change tsoa.json\'s "specVersion" to 3.');
+      // console.warn('Swagger 2.0 does not support union types beyond string literals.\n' + 'If you would like to take advantage of this, please change tsoa.json\'s "specVersion" to 3.');
     }
     return { type: 'object' };
   }


### PR DESCRIPTION
We've been ignoring these warnings for 5 years and will continue to do so until we upgrade to 3.0.
They make build logs a lot noisier than they should be so we might as well hide them.