### PR TITLE
HIGG-32414: Vulnerability - upgrade validator to 13.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "moment": "^2.24.0",
     "typescript": "^3.5.3",
     "typescript-formatter": "^7.2.2",
-    "validator": "^11.1.0",
+    "validator": "^13.7.0",
     "yamljs": "^0.3.0",
     "yargs": "^14.0.0"
   },
@@ -78,7 +78,7 @@
     "@types/sinon": "^7.5.0",
     "@types/superagent": "^4.1.3",
     "@types/supertest": "^2.0.8",
-    "@types/validator": "^10.11.3",
+    "@types/validator": "^13.7.6",
     "@types/yamljs": "^0.2.30",
     "@types/yargs": "^13.0.2",
     "body-parser": "^1.19.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -591,10 +591,10 @@
   dependencies:
     "@types/superagent" "*"
 
-"@types/validator@^10.11.3":
-  version "10.11.3"
-  resolved "https://registry.npmjs.org/@types/validator/-/validator-10.11.3.tgz"
-  integrity sha512-GKF2VnEkMmEeEGvoo03ocrP9ySMuX1ypKazIYMlsjfslfBMhOAtC5dmEWKdJioW4lJN7MZRS88kalTsVClyQ9w==
+"@types/validator@^13.7.6":
+  version "13.12.3"
+  resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.12.3.tgz#af160ddaf1e43ab66fe69473a90b14bb9f435d29"
+  integrity sha512-2ipwZ2NydGQJImne+FhNdhgRM37e9lCev99KnqkbFHd94Xn/mErARWI1RSLem1QA19ch5kOhzIZd7e8CA2FI8g==
 
 "@types/yamljs@^0.2.30":
   version "0.2.30"
@@ -3101,10 +3101,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-validator@^11.1.0:
-  version "11.1.0"
-  resolved "https://registry.npmjs.org/validator/-/validator-11.1.0.tgz"
-  integrity sha512-qiQ5ktdO7CD6C/5/mYV4jku/7qnqzjrxb3C/Q5wR3vGGinHTgJZN/TdFT3ZX4vXhX2R1PXx42fB1cn5W+uJ4lg==
+validator@^13.7.0:
+  version "13.15.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.15.0.tgz#2dc7ce057e7513a55585109eec29b2c8e8c1aefd"
+  integrity sha512-36B2ryl4+oL5QxZ3AzD0t5SsMNGvTtQHpjgFO5tbNxfXbMFkY822ktCDe1MnlqV3301QQI9SLHDNJokDI+Z9pA==
 
 vary@^1.1.2, vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Vulnerability - upgrade validator to 13.7.0
[HIGG-32414](https://worldly.atlassian.net/browse/HIGG-32414)

The validator package is used in templateHelpers class ValidateParam method, which is used in route generation templates.

I tested this (in the api project) by adding a test method on dct-router and generating both the routes and the swagger.

[HIGG-32414]: https://worldly.atlassian.net/browse/HIGG-32414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ